### PR TITLE
Add Read the Docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The PsyInf Knowledge Base
 
-[![Documentation Status](https://readthedocs.org/projects/psyinf-knowledge-base/badge/?version=latest)](https://knowledge-base.psychoinformatics.de/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/psyinf-knowledge-base/badge/?version=latest&style=for-the-badge)](https://knowledge-base.psychoinformatics.de/?badge=latest)
 
 The actual knowledge is in the `kbi/` directory. The knowledge base can be
 rendered in HTML format by running `make html` in the root of the repository

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The PsyInf Knowledge Base
 
+[![Documentation Status](https://readthedocs.org/projects/psyinf-knowledge-base/badge/?version=latest)](https://knowledge-base.psychoinformatics.de/?badge=latest)
+
 The actual knowledge is in the `kbi/` directory. The knowledge base can be
 rendered in HTML format by running `make html` in the root of the repository
 (requires Sphinx).


### PR DESCRIPTION
I often use the GitHub landing page, and the badge in there, to go to the docs page for any given project. I think it would be helpful.

If the "for-the-badge" [style](https://docs.readthedocs.io/en/stable/badges.html#style) is too flamboyant, please revert `0b0571d`.