### PR TITLE
Add a version-tag to KBI prototype

### DIFF
--- a/prototypes/generic.rst_
+++ b/prototypes/generic.rst_
@@ -7,6 +7,7 @@ KBI????: A descriptive title
 :authors: Name <email>
 :discussion: <link>
 :keywords: comma-separated list, aids, discoverability
+:version: datalad version, other version (versions used when crafting the KBI)
 
 An introduction outlining the scope of the KBI
 


### PR DESCRIPTION
Fixes #35 

This PR adds a version tag to the knowledge base item prototype. This could help us to avoid confusion if a user uses a different dataset version than the version that was used during the crafting of a KBI.

Remark: we might have to revisit old KBIs in a few years in order to update the suggested command lines. The version tag could help us to identify possible candidates for such an update
