### PR TITLE
`version` tag is meant to indicate a software version

### DIFF
--- a/prototypes/generic.rst_
+++ b/prototypes/generic.rst_
@@ -7,7 +7,7 @@ KBI????: A descriptive title
 :authors: Name <email>
 :discussion: <link>
 :keywords: comma-separated list, aids, discoverability
-:version: datalad version, other version (versions used when crafting the KBI)
+:software-versions: <name>_<version>, ... (datalad or other version(s) used when crafting the KBI)
 
 An introduction outlining the scope of the KBI
 


### PR DESCRIPTION
In its previous form the tag itself could be easily misintepreted as "version of the KBI".

The documentation now also declares a format to specify package-specific software versions.