### PR TITLE
improve annex artefact removal commands

### DIFF
--- a/kbi/0008/index.rst
+++ b/kbi/0008/index.rst
@@ -94,14 +94,14 @@ Removing the annex from other clones of the dataset
 Any previously existing clone of the newly un-annexed dataset will still contain annex-related data, even after a
 ``datalad update`` from an un-annexed sibling. As a result some data will be stored twice in the
 dataset, once in the worktree and once in the directory ``.git/annex/objects``. In addition
-the sibling will still contain a branch called ``git-annex``. To remove both of these artefacts, execute
-the following commands from the root of your dataset:
+the sibling will contain additional files in the directory ``.git/annex`` and a branch called ``git-annex``.
+To remove both of these artefacts, execute the following commands from the root of your dataset:
 
 .. code-block:: console
 
     > git annex uninit
-    > rm -rf .git/annex
-    > git branch -D git-annex
+    > rm -rf .git/annex/objects/*
+    > git annex uninit
 
 
 


### PR DESCRIPTION
This PR updates the commands that are used to remove the annex. Instead of manually removing files from `.git/annex`, and manually removing the `git-annex` branch, we use `git annex uninit` to remove them.

We use `git annex uninit` twice. The first execution removes the write-protection from `.git/annex/objects/*`, and allows the use of `rm -rf .git/annex/objects*`, to remove the annexed files. The second use of `git annex uninit` removes the `git-annex` branch and the `.git/annex`-directory.

