### PR TITLE
DOCS: add Read the Docs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  fail_on_warning: true


### PR DESCRIPTION
This creates a Read the Docs config file that sets the python version to `3.10` for the build.

Fixes #57