### PR TITLE
0021: Create a KBI on publishing to Zenodo

### DIFF
--- a/kbi/0021/index.rst
+++ b/kbi/0021/index.rst
@@ -5,7 +5,7 @@ KBI0021: Publishing a DataLad dataset to Zenodo
 ===============================================
 
 :authors: Michał Szczepanik <m.szczepanik@fz-juelich.de>
-:discussion: https://github.com/psychoinformatics-de/knowledge-base/issues/24
+:discussion: https://github.com/psychoinformatics-de/knowledge-base/pull/82
 :keywords: zenodo, special remote
 :software-versions: datalad_0.18.3
 

--- a/kbi/0021/index.rst
+++ b/kbi/0021/index.rst
@@ -1,0 +1,50 @@
+.. index::
+   zenodo; publish dataset
+
+KBI0021: Publishing a DataLad dataset to Zenodo
+===============================================
+
+:authors: Michał Szczepanik <m.szczepanik@fz-juelich.de>
+:discussion: https://github.com/psychoinformatics-de/knowledge-base/issues/24
+:keywords: zenodo, special remote
+:software-versions: datalad_0.18.3
+
+This KBI discusses the currently available methods for publishing a
+dataset to `Zenodo`_.
+
+.. _zenodo: https://zenodo.org/
+
+Partial solution 1: archive just the Git repository
+---------------------------------------------------
+
+An easy way to index a dataset in Zenodo is by publishing it to GitHub:
+
+* publish the dataset to GitHub,
+* test whether a clone made from GitHub is able to retrieve data (from other locations),
+* log in to Zenodo and add the GitHub repository,
+* create a release on GitHub to trigger DOI assignment on Zenodo.
+
+`Detailed instructions`_ are available from the Canadian Open
+Neuroscience Platform.
+
+This method can be used to obtain a Zenodo record that corresponds to
+a versioned dataset. However, as GitHub can only hold the Git part of
+the dataset, no annexed files will be stored in Zenodo. Annexed file
+contents will need to be published to a special remote elsewhere.
+
+.. _`detailed instructions`: https://portal.conp.ca/share#datalad
+
+Partial solution 2: upload files using an existing special remote implementation
+--------------------------------------------------------------------------------
+
+We are aware of one git-annex special remote implementation for
+Zenodo, `git-annex-remote-zenodo`_. However, it is described as work
+in progress, and in our testing it showed limited functionality (with
+a small patch we were able to push files to Zenodo, and retrieve them
+back, but only in one and same dataset -- not in a dataset clone).
+
+See the discussion in the `DataLad Handbook repository issue #941`_
+for a description of required steps (including changes to code).
+
+.. _git-annex-remote-zenodo: https://github.com/alegrand/git-annex-remote-zenodo
+.. _datalad handbook repository issue #941: https://github.com/datalad-handbook/book/issues/941

--- a/kbi/0021/index.rst
+++ b/kbi/0021/index.rst
@@ -10,7 +10,7 @@ KBI0021: Publishing a DataLad dataset to Zenodo
 :software-versions: datalad_0.18.3
 
 This KBI discusses the currently available methods for publishing a
-dataset to `Zenodo`_.
+DataLad dataset to `Zenodo`_.
 
 .. _zenodo: https://zenodo.org/
 
@@ -38,10 +38,10 @@ Partial solution 2: upload files using an existing special remote implementation
 --------------------------------------------------------------------------------
 
 We are aware of one git-annex special remote implementation for
-Zenodo, `git-annex-remote-zenodo`_. However, it is described as work
+Zenodo, `git-annex-remote-zenodo`_. However, it is described as a work
 in progress, and in our testing it showed limited functionality (with
 a small patch we were able to push files to Zenodo, and retrieve them
-back, but only in one and same dataset -- not in a dataset clone).
+back, but only in one and the same dataset -- not in a dataset clone).
 
 See the discussion in the `DataLad Handbook repository issue #941`_
 for a description of required steps (including changes to code).


### PR DESCRIPTION
Both presented solutions are partial, but presenting them as they are is the best way to close #24; other than forking / re-implementing a special remote.

The original support issue was continued in https://github.com/datalad-handbook/book/issues/941 which serves both as a tracking issue for the broader problem and an overview of the current state of the existing (not ours) special remote implementation. The KBI links to that issue.