### PR TITLE
KBI0028: Notes on Sciebo/Nextcloud share URLs

### DIFF
--- a/kbi/0007/index.rst
+++ b/kbi/0007/index.rst
@@ -1,6 +1,8 @@
 .. index::
    single: datalad; addurls
 
+.. _kbi0007:
+
 KBI0007: Create a DataLad dataset from a published collection of files
 ======================================================================
 

--- a/kbi/0028/index.rst
+++ b/kbi/0028/index.rst
@@ -1,0 +1,94 @@
+.. index::
+   single: <topic>; <subtopic>
+
+KBI0028: Create a DataLad dataset from Nextcloud (Sciebo) public share links
+============================================================================
+
+:authors: Name <email>
+:discussion: <link>
+:keywords: comma-separated list, aids, discoverability
+:software-versions: <name>_<version>, ... (datalad or other version(s) used when crafting the KBI)
+
+A DataLad dataset can be created directly from an existing collection
+of files in a cloud storage, using share URLs to provide file
+access. Nextcloud, and Nextcloud-based regional university service
+Sciebo, are examples of cloud storage which allows generation of
+folder share URLs with optional password protection. These can be use
+to share data with managed permissions (password or named user), where
+DataLad access is optional.
+
+This document extends KBI0007 in two areas: it introduces the uncurl
+special remote for URL rewriting and credentials access, and focuses
+on Nextcloud-specific URL patterns.
+
+This document deals specifically with files that were deposited in
+Nextcloud without using DataLad. For publishing DataLad datasets to
+Nextcloud, see documentation of the create sibbling webdav command.
+
+Nextcloud URL patterns
+----------------------
+
+There are three primary ways in which a Nextcloud folder can be shared. These will determine the URL patterns which can be used.
+
+Public share link, no password
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the sharing link is password protected, the URL above would not work, as it would redirect requests to a login page. In this case, as well as for sharing with named users only, WebDAV access can be used instead.
+
+Named user share
+^^^^^^^^^^^^^^^^
+
+If a folder is shared with a named user, they will see it in their own account like any other folder, so in principle their access and owner access would be the same, and use an URL starting with:
+
+.. code-block:: none
+
+   https://example.com/nextcloud/remote.php/dav/files/USERNAME/
+
+However, with Nextcloud (Sciebo) being a federated service, each user
+may have a different instance URL to access their data. Additionally,
+the URL includes the username, and each user may place the shared
+directory in a different place within their home directory.
+
+Public share, password protected
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For a folder shared with a password-protected link, the access URLs would start with:
+
+.. code-block:: none
+
+   https://example.com/nextcloud/public.php/webdav
+
+The share token needs to be provided as username, and the (optional) share password as password -- as request credentials, not part of the URL.
+
+URL pattern - summary
+^^^^^^^^^^^^^^^^^^^^^
+
+For the WebDAV url, it is useful to represent the share URL as the list of the following components:
+
+.. code-block:: none
+
+   https://<instance>/<accesspath>/<basepath>/<relpath>
+
+where:
+
+* ``<instance`` is the instance URL
+* ``<accesspath>`` is either ``remote.php/dav/files/USERNAME/`` or
+  ``public.php/webdav``
+* ``<basepath>`` is the path to the shared folder in a given user's
+  home directory (none for public shares)
+* ``<relpath>`` is the path to a particular file relative to the
+  shared folder (``<basepath>``)
+
+Listing files
+-------------
+
+For generating the dataset, a list of file names (relative paths) and
+their respective URLs is needed. These can be generated automatically, e.g. with the webdav4 and fsspec Python libraries.
+
+An example script is given below, using inline comments for explanations.
+
+The example assumes that user's webdav credentials are already known to DataLad under the name ``sciebo`` (if not, these can be added with ``datalad credentials add``, or provided to the script in a different way).
+
+.. literalinclude:: list_files.py
+   :language: python
+

--- a/kbi/0028/index.rst
+++ b/kbi/0028/index.rst
@@ -172,7 +172,7 @@ Finally, files are added to the dataset with ``datalad addurls`` using the previ
 
 .. code-block:: none
 
-   datalad addurls listing.txt https://example.com/nextcloud{href} {name}
+   datalad addurls listing.csv https://example.com/nextcloud{href} {name}
 
 .. _regex101: https://regex101.com
 

--- a/kbi/0028/index.rst
+++ b/kbi/0028/index.rst
@@ -25,9 +25,10 @@ Nextcloud without using DataLad. For publishing DataLad datasets to
 Nextcloud, see the documentation of DataLad-next's
 `create-sibling-webdav`_ command instead.
 
-This document extends :ref:`KBI0007` in two areas: it introduces the
-`uncurl`_ special remote for transforming URLs and using credentials,
-and focuses on Nextcloud-specific URL patterns.
+This document extends the ``addurls``-based approach described in
+:ref:`KBI0007` in two areas: it introduces the `uncurl`_ special
+remote for transforming URLs and using credentials, and focuses on
+Nextcloud-specific URL patterns.
 
 .. _nextcloud: https://nextcloud.com/
 .. _sciebo: https://hochschulcloud.nrw/
@@ -49,7 +50,7 @@ created by appending ``/download?path=<path>&files=<name>`` (where
 ``path`` is a relative path to a directory, and ``name`` is the file
 name). However, if the sharing link is password protected, such URL
 would not work, as it would redirect to a login page (html document)
-and not to file content.
+and not to the file content.
 
 In a general case (share links with or without password, as well as
 sharing with named users), `Nextcloud's webdav access`_ can be
@@ -140,12 +141,14 @@ This would produce the following csv file:
    ...
 	      
 Creating the dataset
--------------
+--------------------
 
-In a DataLad dataset, the process of accessing files that were added via download URLs is handled by a `git-annex special remote`_. The uncurl remote,
-available in the `DataLad-next`_ extension, provides both the ability to
-reconfigure URLs and access to DataLad-next's credential workflow. It
-can be initialized as follows (optionally with ``autoenable=true``) inside a newly created and empty DataLad dataset:
+In a DataLad dataset, the process of accessing files that were added
+via download URLs is handled by a `git-annex special remote`_. The
+uncurl remote, available in the `DataLad-next`_ extension, provides
+both the ability to reconfigure URLs and the access to DataLad-next's
+credential workflow. It can be initialized as follows (optionally with
+``autoenable=true``) inside a DataLad dataset that has been created:
 
 .. _git-annex special remote: https://git-annex.branchable.com/special_remotes/
 .. _DataLad-next: https://github.com/datalad/datalad-next
@@ -177,7 +180,11 @@ Transforming URLs
 -----------------
 
 Assuming the same user moves the folder in their Nextcloud account to
-``some/other/place/``, access to the files in the same DataLad dataset can be retained by setting the URL template of the uncurl remote. The URL template has access to the same identifiers isolated previously with the match expression, and in the case of of this example can use these defined parts with only ``dirpath`` having to change:
+``some/other/place/``, access to the files in the same DataLad dataset
+can be retained by setting the URL template of the uncurl remote. The
+URL template has access to the same identifiers isolated previously
+with the match expression, and in the case of this example can use
+these defined parts with only ``dirpath`` having to change:
 
 .. code-block:: none
 
@@ -198,7 +205,7 @@ Credential caveats
 
 Regardless of whether the files are accessed via the
 ``remote.php/dav/files/USERNAME/`` or ``public.php/webdav`` path, the
-authentication realm for the given nextcloud instance is the
+authentication realm for the given Nextcloud instance is the
 same. This means users who already have DataLad credentials saved for
 the given realm would see their requests for password-protected
 links refused. As long as ``get`` does not support explicit

--- a/kbi/0028/index.rst
+++ b/kbi/0028/index.rst
@@ -1,44 +1,69 @@
 .. index::
-   single: <topic>; <subtopic>
+   single: datalad; addurls
+   single: special remote; uncurl
 
 KBI0028: Create a DataLad dataset from Nextcloud (Sciebo) public share links
 ============================================================================
 
-:authors: Name <email>
-:discussion: <link>
-:keywords: comma-separated list, aids, discoverability
-:software-versions: <name>_<version>, ... (datalad or other version(s) used when crafting the KBI)
+:authors: Michał Szczepanik <m.szczepanik@fz-juelich.de>
+:discussion: https://github.com/psychoinformatics-de/knowledge-base/pull/104
+:keywords: nextcloud, sciebo, webdav, sharing, addurls
+:software-versions: datalad_0.19.2, datalad-next_1.0.0b3, webdav4_0.9.8, fsspec_2023.6.0, sciebo_10.12.2
 
 A DataLad dataset can be created directly from an existing collection
 of files in a cloud storage, using share URLs to provide file
-access. Nextcloud, and Nextcloud-based regional university service
-Sciebo, are examples of cloud storage which allows generation of
-folder share URLs with optional password protection. These can be use
-to share data with managed permissions (password or named user), where
-DataLad access is optional.
-
-This document extends :ref:`KBI0007` in two areas: it introduces the
-uncurl special remote for URL rewriting and credentials access, and
-focuses on Nextcloud-specific URL patterns.
+access. `Nextcloud`_ storage platform (and, by extension, `Sciebo`_, a
+Nextcloud-based regional university service) allows generation of
+folder share URLs with optional password protection and expiration
+time. Creating such share links, as well as granting access to
+specific Nextcloud users, is an option for sharing data with managed
+permissions. In such use case, DataLad is an optional method of
+accessing and indexing data.
 
 This document deals specifically with files that were deposited in
 Nextcloud without using DataLad. For publishing DataLad datasets to
-Nextcloud, see documentation of the create sibbling webdav command.
+Nextcloud, see the documentation of DataLad-next's
+`create-sibling-webdav`_ command instead.
+
+This document extends :ref:`KBI0007` in two areas: it introduces the
+`uncurl`_ special remote for transforming URLs and using credentials,
+and focuses on Nextcloud-specific URL patterns.
+
+.. _nextcloud: https://nextcloud.com/
+.. _sciebo: https://hochschulcloud.nrw/
+.. _create-sibling-webdav: https://docs.datalad.org/projects/next/en/latest/generated/man/datalad-create-sibling-webdav.html
+.. _uncurl: https://docs.datalad.org/projects/next/en/latest/generated/datalad_next.annexremotes.uncurl.html#module-datalad_next.annexremotes.uncurl
 
 Nextcloud URL patterns
 ----------------------
 
-There are three primary ways in which a Nextcloud folder can be shared. These will determine the URL patterns which can be used.
+There are three primary ways in which a Nextcloud folder can be
+shared. These will determine the URL patterns which can be used.
 
 Public share link, no password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the sharing link is password protected, the URL above would not work, as it would redirect requests to a login page. In this case, as well as for sharing with named users only, WebDAV access can be used instead.
+In a special (and simplest) case, if the sharing link for a folder is
+created without password protection, links to individual files can be
+created by appending ``/download?path=<path>&files=<name>`` (where
+``path`` is a relative path to a directory, and ``name`` is the file
+name). However, if the sharing link is password protected, such URL
+would not work, as it would redirect to a login page (html document)
+and not to file content.
+
+In a general case (share links with or without password, as well as
+sharing with named users), `Nextcloud's webdav access`_ can be
+used. The remainder of the document only covers WebDAV URLs.
+
+.. _nextcloud's webdav access: https://docs.nextcloud.com/server/20/user_manual/en/files/access_webdav.html
 
 Named user share
 ^^^^^^^^^^^^^^^^
 
-If a folder is shared with a named user, they will see it in their own account like any other folder, so in principle their access and owner access would be the same, and use an URL starting with:
+If a folder is shared with a named user, they will see it in their own
+account like any other folder. In principle, access for a share
+recipient would be analogous to that of an owner, and use an URL
+starting with:
 
 .. code-block:: none
 
@@ -52,43 +77,133 @@ directory in a different place within their home directory.
 Public share, password protected
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For a folder shared with a password-protected link, the access URLs would start with:
+For a folder shared with a password-protected link, the access URLs
+would start with:
 
 .. code-block:: none
 
    https://example.com/nextcloud/public.php/webdav
 
-The share token needs to be provided as username, and the (optional) share password as password -- as request credentials, not part of the URL.
+The share token (part of the share link) needs to be provided as
+username, and the (optional) share password as password. Note that
+these are sent as request credentials, and are not included in the
+URL.
 
 URL pattern - summary
 ^^^^^^^^^^^^^^^^^^^^^
 
-For the WebDAV url, it is useful to represent the share URL as the list of the following components:
+In summary, it is useful to represent the WebDAV URL as a combination
+of the following components:
 
 .. code-block:: none
 
-   https://<instance>/<accesspath>/<basepath>/<relpath>
+   <instance>/<accesspath>/<dirpath>/<filepath>
 
 where:
 
-* ``<instance`` is the instance URL
+* ``<instance>`` is the instance URL
+  (``https://example.com/nextcloud/`` in given examples)
 * ``<accesspath>`` is either ``remote.php/dav/files/USERNAME/`` or
   ``public.php/webdav``
-* ``<basepath>`` is the path to the shared folder in a given user's
-  home directory (none for public shares)
-* ``<relpath>`` is the path to a particular file relative to the
-  shared folder (``<basepath>``)
+* ``<dirpath>`` is the path to the shared folder in user's home
+  directory (none for public shares)
+* ``<filepath>`` is the path to a particular file relative to the
+  shared folder (``<dirpath>``)
 
 Listing files
 -------------
 
 For generating the dataset, a list of file names (relative paths) and
-their respective URLs is needed. These can be generated automatically, e.g. with the webdav4 and fsspec Python libraries.
+their respective URLs is needed. These can be generated automatically,
+e.g. with the `webdav4`_ and `fsspec`_ Python libraries.
 
 An example script is given below, using inline comments for explanations.
 
-The example assumes that user's webdav credentials are already known to DataLad under the name ``sciebo`` (if not, these can be added with ``datalad credentials add``, or provided to the script in a different way).
+The example assumes that user's webdav credentials are already known
+to DataLad under the name ``webdav-mycred`` (if not, these can be
+added with ``datalad credentials add``, or provided to the script in a
+different way).
+
+.. _webdav4: https://pypi.org/project/webdav4/
+.. _fsspec: https://pypi.org/project/fsspec/
 
 .. literalinclude:: list_files.py
    :language: python
 
+This would produce the following csv file:
+
+.. code-block:: none
+
+   name,href
+   file1.dat,/remote.php/dav/files/USERNAME/sharing/example/file1.dat
+   foo/file2.dat,/remote.php/dav/files/USERNAME/sharing/example/foo/file2.dat
+   ...
+	      
+Uncurl remote
+-------------
+
+Download URLs are handled by special remotes. The uncurl remote,
+available in DataLad-next extension, provides both the ability to
+reconfigure URLs and access to DataLad-next's credential workflow. It
+can be initialized as follows (optionally with ``autoenable=true``):
+
+.. code-block:: none
+
+   git annex initremote uncurl type=external externaltype=uncurl encryption=none
+
+With a known URL pattern (see above), a match expression can be
+defined upfront. The regular expression below is relatively generic,
+with only the dirpath being specific to the given example. Websites
+like `regex101`_ can be helpful in building and understanding the
+expression:
+
+.. code-block:: none
+
+   git annex enableremote uncurl match="(?P<instance>https://[^/]+)/(?P<accesspath>remote\.php/dav/files/[^/]+|public\.php/webdav)/(?P<dirpath>sharing/example)/(?P<filepath>.*)"
+
+The dataset is created based on the previously generated tabular file
+with ``datalad addurls``:
+
+.. code-block:: none
+
+   datalad addurls listing.txt https://example.com/nextcloud{href} {name}
+
+.. _regex101: https://regex101.com
+
+Transforming URLs
+-----------------
+
+Assuming the same user moves the folder in their Nextcloud account to
+``some/other/place/``, the URL configuration can use all the defined
+parts with only ``dirpath`` being different:
+
+.. code-block:: none
+
+   git annex enableremote uncurl url='{instance}/{accesspath}/some/other/place/{filepath}
+
+A different user with whom the dataset is shared would have to
+additionally replace ``accesspath``, and (possibly) ``instance``.
+
+A user with whom the access was shared via a link would need to change
+``accesspath``, and would not be using ``dirpath``:
+
+.. code-block:: none
+
+   git annex enableremote uncurl url='{instance}/public.php/webdav/{filepath}
+
+Credential caveats
+------------------
+
+Regardless of whether the files are accessed via the
+``remote.php/dav/files/USERNAME/`` or ``public.php/webdav`` path, the
+authentication realm for the given nextcloud instance is the
+same. This means users who already have DataLad credentials saved for
+the given realm would be see their requests for password-protected
+links refused. As long as ``get`` does not support explicit
+credentials, this can be worked around by unsetting the credential
+realm.
+
+If a share link is not password protected, the webdav access via
+``public.php/webdav`` can still be used. However, this requires
+creating a DataLad credential with the token as username, and a
+nonempty password (e.g. a single space or ``xyz``) that would not be used.

--- a/kbi/0028/index.rst
+++ b/kbi/0028/index.rst
@@ -17,9 +17,9 @@ folder share URLs with optional password protection. These can be use
 to share data with managed permissions (password or named user), where
 DataLad access is optional.
 
-This document extends KBI0007 in two areas: it introduces the uncurl
-special remote for URL rewriting and credentials access, and focuses
-on Nextcloud-specific URL patterns.
+This document extends :ref:`KBI0007` in two areas: it introduces the
+uncurl special remote for URL rewriting and credentials access, and
+focuses on Nextcloud-specific URL patterns.
 
 This document deals specifically with files that were deposited in
 Nextcloud without using DataLad. For publishing DataLad datasets to

--- a/kbi/0028/index.rst
+++ b/kbi/0028/index.rst
@@ -159,10 +159,12 @@ credential workflow. It can be initialized as follows (optionally with
 
 With a known URL pattern (see above), a match expression for the uncurl special remote can be defined upfront. Defining a match expression allows us to isolate identifiers (such as ``dirpath``, ``filepath``, etc) in the URL pattern, which becomes particularly useful when URLs need to be transformed in future.
 
-The regular expression below is relatively generic,
-with only the ``dirpath`` being specific to the given example. Websites
-like `regex101`_ can be helpful in building and understanding the
-expression:
+The regular expression below is relatively generic, with only the
+``dirpath`` being given explicitly, and specific to the given
+example. Note that if ``dirpath`` included spaces, they would have to
+be `url-encoded`_; otherwise, the uncurl remote would split the
+expression into two. Websites like `regex101`_ can be helpful in
+building and understanding the expression:
 
 .. code-block:: none
 
@@ -175,6 +177,7 @@ Finally, files are added to the dataset with ``datalad addurls`` using the previ
    datalad addurls listing.csv https://example.com/nextcloud{href} {name}
 
 .. _regex101: https://regex101.com
+.. _url-encoded: https://www.w3schools.com/tags/ref_urlencode.asp
 
 Transforming URLs
 -----------------

--- a/kbi/0028/list_files.py
+++ b/kbi/0028/list_files.py
@@ -1,24 +1,31 @@
 import csv
 from pathlib import PurePosixPath
 
-from webdav4.fsspec import WebdavFileSystem
 from datalad.api import credentials
+from webdav4.fsspec import WebdavFileSystem
 
+# Retrieve Nextcloud credentials from DataLad
 cred = credentials(
     "get",
     name="webdav-mycred",
     return_type="item-or-list",
 )
+
+# Create a fsspec filesystem object, with user's Nextcloud home as root
 fs = WebdavFileSystem(
     "https://example.com/nextcloud/remote.php/dav/files/USERNAME/",
     auth=(cred["cred_user"], cred["cred_secret"]),
 )
 
-with open("listing.txt", "wt") as urlfile:
-    writer = csv.writer(urlfile, delimiter="\t")
+# Shared directory, contents of which should be listed
+DIRNAME = "sharing/example"
+
+# List files in the shared directory, writing outputs to a csv file for addurls
+with open("listing.csv", "wt") as urlfile:
+    writer = csv.writer(urlfile, delimiter=",")
     writer.writerow(["name", "href"])
 
-    for dirpath, dirinfo, fileinfo in fs.walk("test-sharing/example2", detail=True):
+    for dirpath, dirinfo, fileinfo in fs.walk(DIRNAME, detail=True):
         # fileinfo is a dict, with file names as keys,
         # and dicts with actual file info as values;
         # we need path ({"name": "..."})
@@ -29,9 +36,6 @@ with open("listing.txt", "wt") as urlfile:
 
             # reported path is relative to root of fs object,
             # what we need is relative to the directory that we walk
-            relpath = PurePosixPath(name).relative_to("test-sharing/example2")
+            relpath = PurePosixPath(name).relative_to(DIRNAME)
 
-            writer.writerow((relpath, href))
-
-# uncurl pattern - may need to adjust slashes a little
-# "(?P<site>https://[^/]+)/(?P<accesspath>remote\.php/dav/files/[^/]+|public\.php/webdav)/(?P<dirpath>test-sharing/example2/)(?P<filepath>.*)"gm
+            writer.writerow([relpath, href])

--- a/kbi/0028/list_files.py
+++ b/kbi/0028/list_files.py
@@ -1,0 +1,37 @@
+import csv
+from pathlib import PurePosixPath
+
+from webdav4.fsspec import WebdavFileSystem
+from datalad.api import credentials
+
+cred = credentials(
+    "get",
+    name="webdav-mycred",
+    return_type="item-or-list",
+)
+fs = WebdavFileSystem(
+    "https://example.com/nextcloud/remote.php/dav/files/USERNAME/",
+    auth=(cred["cred_user"], cred["cred_secret"]),
+)
+
+with open("listing.txt", "wt") as urlfile:
+    writer = csv.writer(urlfile, delimiter="\t")
+    writer.writerow(["name", "href"])
+
+    for dirpath, dirinfo, fileinfo in fs.walk("test-sharing/example2", detail=True):
+        # fileinfo is a dict, with file names as keys,
+        # and dicts with actual file info as values;
+        # we need path ({"name": "..."})
+        # and URL compnent ({"href": "remote.php/dav/..."})
+        for f in fileinfo.values():
+            name = f["name"]
+            href = f["href"]
+
+            # reported path is relative to root of fs object,
+            # what we need is relative to the directory that we walk
+            relpath = PurePosixPath(name).relative_to("test-sharing/example2")
+
+            writer.writerow((relpath, href))
+
+# uncurl pattern - may need to adjust slashes a little
+# "(?P<site>https://[^/]+)/(?P<accesspath>remote\.php/dav/files/[^/]+|public\.php/webdav)/(?P<dirpath>test-sharing/example2/)(?P<filepath>.*)"gm


### PR DESCRIPTION
It did not come up as a support event (i.e. "nobody asked for this"), but this goes back to something we considered for an archival request (internal issue tracker) and something I later explored for myself, so I think knowledge base is an useful place to document that with better visibility.

Features Nextcloud / Sciebo specific details, and a practical example of an uncurl remote. Writing it up was very educational for me.