### PR TITLE
Add KBI on RIA store improvements in -next

### DIFF
--- a/kbi/0032/index.rst
+++ b/kbi/0032/index.rst
@@ -8,7 +8,7 @@ KBI0032: Pushing to RIA-store between OSs, and other improvements
 :authors: Michał Szczepanik <m.szczepanik@fz-juelich.de>
 :discussion: https://github.com/psychoinformatics-de/knowledge-base/pull/125
 :keywords: datalad-next, RIA, macOS, linux, windows, cross-platform
-:software-versions: datalad-next_1.4.1, datalad_1.0.2
+:software-versions: datalad-next_1.4.1, datalad_1.0.2, datalad_1.1.2
 
 DataLad versions prior to 1.1.2 can display the
 following error when pushing to a RIA store from macOS to a linux
@@ -22,16 +22,17 @@ server [#f2]_:
 This can be translated as: DataLad tried to execute the ``stat``
 command on Linux, with macOS-specific parameterization (``-f%Dp``).
 
-A fix, together with a set of other improvements to to the RIA
-functionality of DataLad, has been released in the DataLad-next
-extension, in v.1.4.1 (`changelog`_).
+This particular behavior was fixed in DataLad v.1.1.2
+(`changelog`_).  The fix, together with a set of other
+improvements to to the RIA functionality of DataLad, had been first
+shipped in the DataLad-next extension, in v.1.4.1 (`changelog-next`_).
 
 Additionally, the 1.4 release of DataLad-next replaces most of the RIA
 implementation, including the ORA special remote, and the
 create-sibling-ria command. The new implementation brings uniform
 support for Windows clients, progress reporting for uploads and
 downloads via SSH, and a faster and more robust behavior for SSH-based
-operations (from `changelog`_).
+operations (from `changelog-next`_).
 
 `DataLad-next`_ is a separate Python package (`DataLad extension`_),
 and can be installed e.g. with ``pip``. It is also available as a
@@ -46,7 +47,8 @@ installation to allow it to override default DataLad behavior.
          Debian stable is 1.2.0, which does not contain a fix to the
          issues described above.
 
-.. _changelog: https://github.com/datalad/datalad-next/blob/main/CHANGELOG.md#140-2024-05-17
+.. _changelog: https://github.com/datalad/datalad/blob/maint/CHANGELOG.md#112-2024-07-25
+.. _changelog-next: https://github.com/datalad/datalad-next/blob/main/CHANGELOG.md#140-2024-05-17
 .. _DataLad-next: https://docs.datalad.org/projects/next/en/latest/
 .. _pull request: https://github.com/datalad/datalad/pull/7549
 .. _GitHub issue: https://github.com/datalad/datalad/issues/7536

--- a/kbi/0032/index.rst
+++ b/kbi/0032/index.rst
@@ -10,7 +10,7 @@ KBI0032: Pushing to RIA-store between OSs, and other improvements
 :keywords: datalad-next, RIA, macOS, linux, windows, cross-platform
 :software-versions: datalad-next_1.4.1, datalad_1.0.2
 
-DataLad versions prior to at least 1.0.2 [#f1]_ can display the
+DataLad versions prior to 1.1.2 can display the
 following error when pushing to a RIA store from macOS to a linux
 server [#f2]_:
 
@@ -40,10 +40,6 @@ config --global --add datalad.extensions.load next``) after
 installation to allow it to override default DataLad behavior.
 
 .. rubric:: Footnotes
-
-.. [#f1] At the moment of writing it is not known if and when a fix
-         will be included in the core DataLad package. A `pull
-         request`_ has been proposed.
 .. [#f2] Reported e.g. in this `GitHub issue`_ and this `Neurostars
          thread`_, which prompted this KBI.
 .. [#f3] At the moment of writing, the latest version available in

--- a/kbi/0032/index.rst
+++ b/kbi/0032/index.rst
@@ -1,0 +1,58 @@
+.. index::
+   single: RIA; cross-platform
+   single: datalad-next; RIA
+
+KBI0032: Pushing to RIA-store between OSs, and other improvements
+=================================================================
+
+:authors: Michał Szczepanik <m.szczepanik@fz-juelich.de>
+:discussion: https://github.com/psychoinformatics-de/knowledge-base/pull/125
+:keywords: datalad-next, RIA, macOS, linux, windows, cross-platform
+:software-versions: datalad-next_1.4.1, datalad_1.0.2
+
+DataLad versions prior to at least 1.0.2 [#f1]_ can display the
+following error when pushing to a RIA store from macOS to a linux
+server [#f2]_:
+
+.. code-block:: none
+
+   Unable to remove <remote-store-path>/...//.../transfer/<annex-key> or to obtain write permission in parent directory. -caused by- stat -f%Dp <remote-store-path>/...//.../transfer failed:
+   copy: 1 failed
+
+This can be translated as: DataLad tried to execute the ``stat``
+command on Linux, with macOS-specific parameterization (``-f%Dp``).
+
+A fix, together with a set of other improvements to to the RIA
+functionality of DataLad, has been released in the DataLad-next
+extension, in v.1.4.1 (`changelog`_).
+
+Additionally, the 1.4 release of DataLad-next replaces most of the RIA
+implementation, including the ORA special remote, and the
+create-sibling-ria command. The new implementation brings uniform
+support for Windows clients, progress reporting for uploads and
+downloads via SSH, and a faster and more robust behavior for SSH-based
+operations (from `changelog`_).
+
+`DataLad-next`_ is a separate Python package (`DataLad extension`_),
+and can be installed e.g. with ``pip``. It is also available as a
+Debian package [#f3]_. It needs to be enabled (``git
+config --global --add datalad.extensions.load next``) after
+installation to allow it to override default DataLad behavior.
+
+.. rubric:: Footnotes
+
+.. [#f1] At the moment of writing it is not known if and when a fix
+         will be included in the core DataLad package. A `pull
+         request`_ has been proposed.
+.. [#f2] Reported e.g. in this `GitHub issue`_ and this `Neurostars
+         thread`_, which prompted this KBI.
+.. [#f3] At the moment of writing, the latest version available in
+         Debian stable is 1.2.0, which does not contain a fix to the
+         issues described above.
+
+.. _changelog: https://github.com/datalad/datalad-next/blob/main/CHANGELOG.md#140-2024-05-17
+.. _DataLad-next: https://docs.datalad.org/projects/next/en/latest/
+.. _pull request: https://github.com/datalad/datalad/pull/7549
+.. _GitHub issue: https://github.com/datalad/datalad/issues/7536
+.. _Neurostars thread: https://neurostars.org/t/datalad-push-to-ria-storage-not-working/29049
+.. _DataLad extension: https://handbook.datalad.org/en/latest/extension_pkgs.html


### PR DESCRIPTION
DataLad-next 1.4 patches most of the RIA code, improving it in many aspects. One particular improvement is related to a `stat` command error when pushing from macOS to linux. That error has been reported several times in different places (GitHub issue tracker, Neurostars, office hour).

This KBI is a rephrasing of my post in a [Neurostars thread](https://neurostars.org/t/datalad-push-to-ria-storage-not-working/29049). I wrote that post mostly to provide a reference to the changes for future visitors looking for an answer (the response is 2 months older than the question, asked before the RIA fixes were released). The answer is now repeated here, to provide a persistent record in a place controlled by us (in terms of availability) -- granted, Neurostars is a friendly and trustworthy place (compared to what StackOverflow or Reddit have become), but it is still an external forum.

For this reason, if the KBI is seen redundant, I am also happy to close it right away.