### PR TITLE
Add RTD-recommended configuration ahead of deprecations

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,3 +25,13 @@ html_theme = 'furo'
 html_static_path = ['_static']
 html_logo = '_static/logo.png'
 html_title = ''
+
+# see https://about.readthedocs.com/blog/2024/07/addons-by-default/ for the
+# reasoning behind the following:
+import os
+html_context = {}
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True


### PR DESCRIPTION
In an email to maintainers of affected projects, readthedocs advised to make configuration changes ahead of the deprecation of injecting Sphinx- related configurations during build time.
For more info, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/