### PR TITLE
Add more information about keyring backends & dependencies

### DIFF
--- a/kbi/0023/index.rst
+++ b/kbi/0023/index.rst
@@ -11,7 +11,7 @@ KBI0023: Keyring configuration
 :keywords: keyring, credentials
 :software-versions: datalad_0.18.3, datalad-next_0.6.3
 
-This KBI covers keyring configuration in the context of a problem with
+This KBI covers keyring configuration in the context of problems with
 credential retrieval observed on a headless system. It also provides a
 general overview of keyring access.
 
@@ -22,6 +22,47 @@ DataLad uses the `Keyring`_ Python library to communicate with keyring
 backends available on the given system to store user's credentials.
 
 .. _Keyring: https://keyring.readthedocs.io/
+
+Keyring information, including the active backends and the location of
+a keyring configuration file, can always be found in the output of
+``datalad wtf``::
+
+  $ datalad wtf --section credentials
+  # WTF
+  ## credentials
+  - keyring:
+    - active_backends:
+      - SecretService Keyring
+      - PlaintextKeyring with no encryption v.1.0 at /home/jdoe/.local/share/python_keyring/keyring_pass.cfg
+    - config_file: /home/jdoe/.config/python_keyring/keyringrc.cfg
+    - data_root: /home/jdoe/.local/share/python_keyring
+
+The Keyring Python package also has its own CLI, which can report the
+backends as well (different configuration shown)::
+
+  $ keyring --list-backends
+  keyring.backends.fail.Keyring (priority: 0)
+  keyrings.alt.file.EncryptedKeyring (priority: 0.6)
+  keyring.backends.chainer.ChainerBackend (priority: 10)
+  keyrings.alt.file.PlaintextKeyring (priority: 0.5)
+
+Some notable backends include:
+
+- SecretService Keyring (``keyring.backends.SecretService.Keyring``):
+  an interface to system daemons such as the GNOME Keyring and KDE
+  Wallet. This one is the one most likely to be used on Linux
+  desktops.
+- EncryptedKeyring (``keyrings.alt.file.EncryptedKeyring``): passwords
+  are stored in an encrypted text file. Provided by ``keyrings.alt``
+  Python package but additionally requiring ``pycryptodomex`` to be
+  installed.
+- PlaintextKeyring (``keyrings.alt.file.PlaintextKeyring``): passwords
+  are base64-encoded and stored in a plaintext file for which only the
+  owner has read and write permissions. Provided by ``keyrings.alt``
+  Python package.
+
+Problem: Secret Service available but unusable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If GNOME Keyring is installed on a system, but a D-Bus session is not
 started after login (the latter is likely to be the case on headless
@@ -38,19 +79,18 @@ The error would appear for any operation requiring credential access
   [DEBUG  ] Importing keyring
   [ERROR  ] Failed to create the collection: Prompt dismissed.
 
-Keyring information, including the active backends and the location of
-a keyring configuration file, can always be found in the output of
-``datalad wtf``::
 
-  $ datalad wtf --section credentials
-  # WTF
-  ## credentials 
-  - keyring: 
-    - active_backends: 
-      - SecretService Keyring
-      - PlaintextKeyring with no encryption v.1.0 at /home/jdoe/.local/share/python_keyring/keyring_pass.cfg
-    - config_file: /home/jdoe/.config/python_keyring/keyringrc.cfg
-    - data_root: /home/jdoe/.local/share/python_keyring
+Problem: available backends change when activating a virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a backend is provided by a Python package installed system-wide, it
+may become "invisible" after activating a virtual environment which
+lacks the package or its optional dependencies. In this case, DataLad
+would not be able to access passwords saved previously with a given
+backend, and would prompt for their entry (and then optionally store
+them with another backend). The ``datalad wtf --section credentials``
+listing would not include the unavailable backend.
+
 
 User solution 1: configure preferred keyring
 --------------------------------------------
@@ -86,7 +126,24 @@ creating the file if needed:
    sufficient for some setups and use cases, but is not recommended in
    general.
 
-User solution 2: start a D-bus session
+
+User solution 2: install required packages
+------------------------------------------
+
+If the problem is related to a Python library missing in the (virtual)
+environment, it can be solved by installing it.
+
+This is not always obvious. For example, the encrypted (file) keyring
+is provided by ``keyrings.alt``, but is only active when an optional
+dependency, ``pycryptodomex`` is present. Installing both will enable
+it (by default with a higher priority than the plaintext
+keyring). Python package for DataLad lists ``keyring`` and
+``keyrings.alt`` as dependencies, but neither of them strictly depends
+on ``pycryptodomex``, so the latter needs to be installed separately
+[#]_.
+
+
+User solution 3: start a D-bus session
 --------------------------------------
 
 Keyring library documentation provides another solution for `using
@@ -106,3 +163,9 @@ will prevent Keyring library from trying to use it::
 
 This will likely cause Keyring to use the plaintext keyring as a
 backup; see note above for security considerations.
+
+
+.. [#] interestingly, ``python3-keyrings.alt`` Debian package does
+       depend on ``python3-pycryptodome``, at least as of version
+       4.2.0-1. See:
+       https://packages.debian.org/stable/python/python3-keyrings.alt


### PR DESCRIPTION
This introduces a small restructuring and extension of KBI0023: Keyring configuration to address a recently observed case where the encrypted file keyring was used in the base environment but not a virtual environment, due to (un)availability of PyCryptodome.

- moved the `datalad wtf --section credentials` example higher; now it is part of the introduction, before problems are described

- added an information about listing backends with keyring's CLI

- explained SecretService, EncryptedKeyring, and PlaintextKeyring which are likely to come into play

- there are now two problems with separate subheadings; one old (SecretService), one new (EncryptedKeyring)

- added a new user solution, explaining that EncryptedKeyring requires PyCryptodome, which may not get installed automatically in virtualenvs, to become active

Although problems with SecretService and EncryptedKeyring showed up separately, there is a partial overlap in solutions and a large overlap in explanations, so it seems more appropriate to extend this KBI instead of creating a separate one.

---

All the children say:

We don't need another hero
We don't need to know the way `/home`
All we want is life beyond
PyCryptodome