### PR TITLE
Update Python version to 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 sphinx:
   fail_on_warning: true


### PR DESCRIPTION
After all... why not? Not related to any breakage, but should help longevity.

Updates Python version used for ReadTheDocs builds.